### PR TITLE
Fix Pin Switching to use written value

### DIFF
--- a/src/arduino101/science-journal-arduino/science-journal-arduino.ino
+++ b/src/arduino101/science-journal-arduino/science-journal-arduino.ino
@@ -62,7 +62,7 @@ void bleNotificationUnsubscribeHandler(BLECentral& central, BLECharacteristic& c
 void bleConfigChangeHandler(BLECentral& central, BLECharacteristic& characteristic) {
   // config characteristic event handler
   DEBUG_PRINTLN("config change event");
-  handle( (uint8_t*) config, 20);
+  handle( (uint8_t*) characteristic.value(), characteristic.valueLength());
   DEBUG_PRINT("Pin: ");
   DEBUG_PRINTLN(pin);
 }


### PR DESCRIPTION
Reads written characteristic values and passes them to the parser to get pin.
