### PR TITLE
update for pio 3.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .pioenvs
 .clang_complete
 .gcc-flags.json
+.piolibdeps

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,6 @@ platform = atmelavr
 framework = arduino
 board = blend
 src_filter = +<blend/>
-=======
 lib_deps =
 	EEPROM
 	SPI

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,40 +17,39 @@
 # Automatic targets - enable auto-uploading
 # targets = upload
 
+[platformio]
+lib_install = BLEPeripheral, ble-sdk-arduino, nanopb
+
 [env:blend]
 platform = atmelavr
 framework = arduino
 board = blend
 src_filter = +<blend/>
-lib_use = SPI,EEPROM
-lib_dfcyclic = True
-lib_install = 431,332
-lib_ignore = BLEPeripheral_ID259
+lib_force = SPI, EEPROM, ble-sdk-arduino, goosci
+lib_ignore = BLEPeripheral
+# force goosci for now, fix the circular dependency between GoosciBleGatt and goosci
+build_flags = !echo "-I$(pwd)/lib/goosci"
 
 [env:101]
 platform = intel_arc32
 framework = arduino
 board = genuino101
 src_filter = +<arduino101/>
-lib_install = 431
-lib_ignore = Nordic_nRF8001,GoosciBleGatt,BLEPeripheral_ID259
+lib_force = SPI
+lib_ignore = GoosciBleGatt, BLEPeripheral
 
 [env:mega2560]
 platform = atmelavr
 framework = arduino
 board = megaatmega2560
 src_filter = +<arduino/>
-lib_use = SPI,EEPROM
-lib_dfcyclic = True
-lib_install = 259
-lib_ignore = GoosciBleGatt,ble_sdk_arduino_ID332,Nordic_nRF8001
+lib_force = SPI, EEPROM, BLEPeripheral, goosci
+lib_ignore = ble-sdk-arduino, GoosciBleGatt
 
 [env:uno]
 platform = atmelavr
 framework = arduino
 board = uno
 src_filter = +<arduino/>
-lib_use = SPI,EEPROM
-lib_dfcyclic = True
-lib_install = 259
-lib_ignore = GoosciBleGatt,ble_sdk_arduino_ID332,Nordic_nRF8001
+lib_force = SPI, EEPROM, BLEPeripheral, goosci
+lib_ignore = ble-sdk-arduino, GoosciBleGatt


### PR DESCRIPTION
Updated to use the new PlatformIO 3.x LDR.  There is still a problem between lib/goosci and lib/GoosciBleGatt having circular dependencies, but I worked around it with build flags.