### PR TITLE
Switch to PlatformIO 3.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ lib_deps =
 	ble-sdk-arduino
 	Nanopb
 ; force goosci for now, fix the circular dependency between GoosciBleGatt and goosci
-build_flags = !echo "-I$(pwd)/lib/goosci"
+build_flags = -I$PROJECT_DIR/lib/goosci
 
 [env:101]
 platform = intel_arc32

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,56 +1,47 @@
-#
-# Project Configuration File
-#
-# A detailed documentation with the EXAMPLES is located here:
-# http://docs.platformio.org/en/latest/projectconf.html
-#
-
-# A sign `#` at the beginning of the line indicates a comment
-# Comment lines are ignored.
-
-# Simple and base environment
-# [env:mybaseenv]
-# platform = %INSTALLED_PLATFORM_NAME_HERE%
-# framework =
-# board =
-#
-# Automatic targets - enable auto-uploading
-# targets = upload
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter, extra scripting
+;   Upload options: custom port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/en/stable/projectconf.html
 
 [env:blend]
 platform = atmelavr
 framework = arduino
 board = blend
 src_filter = +<blend/>
-lib_use = SPI,EEPROM
-lib_dfcyclic = True
-lib_install = 431,332
-lib_ignore = BLEPeripheral_ID259
+lib_deps =
+	EEPROM
+	SPI
+	ble-sdk-arduino
+	Nanopb
 
 [env:101]
 platform = intel_arc32
 framework = arduino
 board = genuino101
 src_filter = +<arduino101/>
-lib_install = 431
-lib_ignore = Nordic_nRF8001,GoosciBleGatt,BLEPeripheral_ID259
+lib_deps = Nanopb
+lib_ignore = GoosciBleGatt, BLEPeripheral
 
 [env:mega2560]
 platform = atmelavr
 framework = arduino
 board = megaatmega2560
 src_filter = +<arduino/>
-lib_use = SPI,EEPROM
-lib_dfcyclic = True
-lib_install = 259
-lib_ignore = GoosciBleGatt,ble_sdk_arduino_ID332,Nordic_nRF8001
+lib_deps =
+	SPI
+	BLEPeripheral@^0.3.1
+lib_ignore = GoosciBleGatt
 
 [env:uno]
 platform = atmelavr
 framework = arduino
 board = uno
 src_filter = +<arduino/>
-lib_use = SPI,EEPROM
-lib_dfcyclic = True
-lib_install = 259
-lib_ignore = GoosciBleGatt,ble_sdk_arduino_ID332,Nordic_nRF8001
+lib_deps =
+	SPI
+	BLEPeripheral@^0.3.1
+lib_ignore = GoosciBleGatt

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,8 @@ lib_deps =
 	SPI
 	ble-sdk-arduino
 	Nanopb
+; force goosci for now, fix the circular dependency between GoosciBleGatt and goosci
+build_flags = !echo "-I$(pwd)/lib/goosci"
 
 [env:101]
 platform = intel_arc32


### PR DESCRIPTION
Please fix "Circular dependencies detected between `lib/GoosciBleGatt` and `lib/goosci`". Looks like need to refactor these libs to avoid processor recursion.

P.S: "I signed it!"